### PR TITLE
fix(build): fix luarocks install of openssl 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         submodules: 'true'
     - name: Run Tests
-      run: docker compose up tests
+      run: docker compose build --no-cache && docker compose up tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,9 @@ ARG FIX_DEPENDENCIES="gcc musl-dev"
 RUN if [ -x "$(command -v apk)" ]; then apk add --no-cache $FIX_DEPENDENCIES; \
     elif [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install $FIX_DEPENDENCIES; \
     fi; \
-    luarocks install luaossl OPENSSL_DIR=/usr/local/kong CRYPTO_DIR=/usr/local/kong; \
+    # --only-server fix based on https://support.konghq.com/support/s/article/LuaRocks-Error-main-function-has-more-than-65536-constants
+    luarocks --only-server https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/daab2726276e3282dc347b89a42a5107c3500567 \
+      install luaossl OPENSSL_DIR=/usr/local/kong CRYPTO_DIR=/usr/local/kong; \
     if [ -x "$(command -v apk)" ]; then apk del $FIX_DEPENDENCIES; \
     elif [ -x "$(command -v apt-get)" ]; then apt-get remove --purge -y $FIX_DEPENDENCIES; \
     fi


### PR DESCRIPTION
* fix(build): fix luarocks install of openssl due to error: https://support.konghq.com/support/s/article/LuaRocks-Error-main-function-has-more-than-65536-constants
* fix(test): fix test execution with docker compose