### PR TITLE
feat(ci): add image expiry labels for non-main branch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,17 @@ jobs:
           fi
           echo "Image tag will be: ${TAG}"
           echo "image-tag=${TAG}" >> "${GITHUB_OUTPUT}"
+      - name: Determine image labels
+        # Apply Quay expiry only to branch builds that are not main; tags stay permanent.
+        id: image-labels
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "labels=" >> "${GITHUB_OUTPUT}"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "labels=" >> "${GITHUB_OUTPUT}"
+          else
+            echo "labels=quay.expires-after=60d" >> "${GITHUB_OUTPUT}"
+          fi
       - name: Login to registry
         uses: docker/login-action@v3
         with:
@@ -83,6 +94,8 @@ jobs:
           tags: ${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}:${{ steps.tag.outputs.image-tag }}
           cache-from: type=registry,ref=${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}:latest
           cache-to: type=inline
+          provenance: false
+          labels: ${{ steps.image-labels.outputs.labels }}
           push: true
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
Add logic to set quay.expires-after=60d label on images built from feature branches, while keeping main branch and tag builds permanent. Also disable provenance attestation in build process because they break MTR.