### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ on:
     branches:
       - main
     tags:
+      - '*'
 
 permissions:
   contents: read
@@ -43,7 +44,7 @@ jobs:
       image-tag: ${{ steps.build-push.outputs.image-digest }}
     steps:
       - name: Inject slug vars
-        uses: rlespinasse/github-slug-action@v5
+        uses: rlespinasse/github-slug-action@9e7def61550737ba68c62d34a32dd31792e3f429 #v5.5.0
       - name: Determine tag
         id: tag
         run: |
@@ -76,18 +77,18 @@ jobs:
             echo "labels=quay.expires-after=60d" >> "${GITHUB_OUTPUT}"
           fi
       - name: Login to registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           registry: ${{ vars.REGISTRY_HOST }}
           username: ${{ vars.REGISTRY_AUTH_USER }}
           password: ${{ secrets.REGISTRY_AUTH_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 #v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
       - name: Build and push
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 #v6.19.2
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
@@ -99,7 +100,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad #v4.0.0
         with:
           cosign-release: 'v2.5.3'
       - name: Sign image using cosign
@@ -137,7 +138,7 @@ jobs:
       - build-push-image
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
         env:
           TRIVY_USERNAME: ${{ vars.REGISTRY_AUTH_USER }}
           TRIVY_PASSWORD: ${{ secrets.REGISTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,14 @@ jobs:
       new-release-version: ${{ steps.semantic-release.outputs.new-release-version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: "true"
 
       - name: Semantic Release
         id: semantic-release
-        uses: cycjimmy/semantic-release-action@v5
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 #v6.0.0
         with:
           extra_plugins: |
             semantic-release-export-data
@@ -52,7 +52,7 @@ jobs:
       actions: write
     steps:
       - name: Trigger build
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -12,6 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 #v6.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   test-plugins:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       with:
         submodules: 'true'
     - name: Run Tests


### PR DESCRIPTION
Pin all GitHub Actions to specific commit SHAs for security and reproducibility. Add wildcard tag trigger to build workflow to enable builds for all tags.