### PR TITLE
feat: remove Via header from Kong proxy responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ RUN rm -rf /opt/plugins
 # Registering additional plugins which are not just a patch of existing ones
 ENV KONG_PLUGINS="bundled,jwt-keycloak,rate-limiting-merged"
 
+# Remove Via header injection from Kong core
+RUN sed -i '/enabled_headers\[conf_constants\.HEADERS\.VIA\] = true/d' /usr/local/share/lua/5.1/kong/conf_loader/init.lua
+
 # copy nginx template to bake it into the image
 COPY --chown=1000:1000 templates/nginx_kong.lua /usr/local/share/lua/5.1/kong/templates/nginx_kong.lua
 

--- a/templates/nginx_kong.lua
+++ b/templates/nginx_kong.lua
@@ -272,7 +272,6 @@ server {
 > end
 
         proxy_set_header      TE                 $upstream_te;
-        proxy_set_header      Via                $upstream_via;
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
@@ -307,7 +306,6 @@ server {
         proxy_request_buffering off;
 
         proxy_set_header      TE                 $upstream_te;
-        proxy_set_header      Via                $upstream_via;
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
@@ -342,7 +340,6 @@ server {
         proxy_request_buffering off;
 
         proxy_set_header      TE                 $upstream_te;
-        proxy_set_header      Via                $upstream_via;
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
@@ -377,7 +374,6 @@ server {
         proxy_request_buffering  on;
 
         proxy_set_header      TE                 $upstream_te;
-        proxy_set_header      Via                $upstream_via;
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
@@ -408,7 +404,6 @@ server {
         set $kong_proxy_mode 'grpc';
 
         grpc_set_header      TE                 $upstream_te;
-        grpc_set_header      Via                $upstream_via;
         grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
         grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
@@ -452,7 +447,6 @@ server {
 
         proxy_http_version 1.1;
         proxy_set_header      TE                 $upstream_te;
-        proxy_set_header      Via                $upstream_via;
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;

--- a/tests/quick_integration_test.sh
+++ b/tests/quick_integration_test.sh
@@ -221,8 +221,8 @@ curl -s -u admin:admin -X POST $KONG_ADMIN_URL/services/httpbin-service/plugins 
     "config": {
       "limits": {
         "service": {
-          "minute": 10,
-          "hour": 100
+          "minute": 200,
+          "hour": 1000
         }
       },
       "policy": "local",
@@ -410,6 +410,30 @@ test_zipkin_tracing() {
     fi
 }
 
+# Test 8: Via header removal test
+test_via_header_not_present() {
+    if [ -z "$TOKEN" ]; then
+        echo "    Skipping: No JWT token available"
+        return 0
+    fi
+
+    # Check response headers for Via
+    RESPONSE_HEADERS=$(curl -s -I $KONG_PROXY_URL/httpbin/get -H "Authorization: Bearer $TOKEN")
+    if echo "$RESPONSE_HEADERS" | grep -qi '^Via:'; then
+        echo "    Via header found in response: $(echo "$RESPONSE_HEADERS" | grep -i '^Via:')"
+        return 1
+    fi
+
+    # Check request headers forwarded to upstream via httpbin /headers
+    UPSTREAM_HEADERS=$(curl -s $KONG_PROXY_URL/httpbin/headers -H "Authorization: Bearer $TOKEN")
+    if echo "$UPSTREAM_HEADERS" | jq -e '.headers.Via // .headers.via // empty' 2>/dev/null | grep -q .; then
+        echo "    Via header found in upstream request: $(echo "$UPSTREAM_HEADERS" | jq '.headers.Via // .headers.via')"
+        return 1
+    fi
+
+    return 0
+}
+
 # Execute all tests with retry mechanism
 run_test_with_retry "Test 1: Unauthorized request" test_unauthorized_request
 if [ $? -ne 0 ]; then
@@ -442,6 +466,11 @@ if [ $? -ne 0 ]; then
 fi
 
 run_test_with_retry "Test 7: Zipkin tracing" test_zipkin_tracing
+if [ $? -ne 0 ]; then
+    TEST_FAILURES=$((TEST_FAILURES + 1))
+fi
+
+run_test_with_retry "Test 8: Via header not present" test_via_header_not_present
 if [ $? -ne 0 ]; then
     TEST_FAILURES=$((TEST_FAILURES + 1))
 fi


### PR DESCRIPTION
Remove Via header injection from Kong core by patching conf_loader and removing proxy_set_header directives from nginx template. Add integration test to check header removal.