### PR TITLE
feat: bump jwt-keycloak plugin version to 1.8.0-1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external-plugins/jwt-keycloak"]
 	path = external-plugins/jwt-keycloak
 	url = https://github.com/telekom/kong-plugin-jwt-keycloak.git
-	tag = 1.7.0-1
+	tag = 1.8.0-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /tmp
 
 COPY ./external-plugins/jwt-keycloak/*.rockspec /tmp
 COPY ./external-plugins/jwt-keycloak/src /tmp/src
-ARG PLUGIN_VERSION=1.7.0-1
+ARG PLUGIN_VERSION=1.8.0-1
 RUN luarocks make && luarocks pack kong-plugin-jwt-keycloak ${PLUGIN_VERSION}
 
 
@@ -32,7 +32,7 @@ COPY --from=jwt-keycloak-builder /tmp/*.rock /tmp/
 USER root
 
 # Install jwt-keycloak plugin
-ARG PLUGIN_VERSION=1.7.0-1
+ARG PLUGIN_VERSION=1.8.0-1
 RUN luarocks install /tmp/kong-plugin-jwt-keycloak-${PLUGIN_VERSION}.all.rock
 
 # copy other plugins from repo to image


### PR DESCRIPTION
## Context

Picks up the `JWT_KEYCLOAK_BLOCKED_ISSUERS` zone-wide issuer blocklist added in telekom/kong-plugin-jwt-keycloak#12.

See that PR for full context on the Mesh LMS threat model (DHEI-19942) and the emergency measure design.

## Changes

- `Dockerfile` — bump `PLUGIN_VERSION` from `1.7.0-1` to `1.8.0-1` (both build and install stages)

## Merge order

This should be merged after telekom/kong-plugin-jwt-keycloak#12 is released as `1.8.0`.

DHEI-19943