### PR TITLE
fix: bump jwt-keycloak plugin version to 1.8.1-1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external-plugins/jwt-keycloak"]
 	path = external-plugins/jwt-keycloak
 	url = https://github.com/telekom/kong-plugin-jwt-keycloak.git
-	tag = 1.8.0-1
+	tag = 1.8.1-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /tmp
 
 COPY ./external-plugins/jwt-keycloak/*.rockspec /tmp
 COPY ./external-plugins/jwt-keycloak/src /tmp/src
-ARG PLUGIN_VERSION=1.8.0-1
+ARG PLUGIN_VERSION=1.8.1-1
 RUN luarocks make && luarocks pack kong-plugin-jwt-keycloak ${PLUGIN_VERSION}
 
 
@@ -32,7 +32,7 @@ COPY --from=jwt-keycloak-builder /tmp/*.rock /tmp/
 USER root
 
 # Install jwt-keycloak plugin
-ARG PLUGIN_VERSION=1.8.0-1
+ARG PLUGIN_VERSION=1.8.1-1
 RUN luarocks install /tmp/kong-plugin-jwt-keycloak-${PLUGIN_VERSION}.all.rock
 
 # copy other plugins from repo to image


### PR DESCRIPTION
## Context

Picks up the `allowed_iss` exact-match security fix from telekom/kong-plugin-jwt-keycloak#13.

`allowed_iss` entries were previously matched via Lua `string.match()`, treating them as patterns. Unescaped dots acted as wildcards and unanchored matching allowed substring attacks. Fixed in 1.8.1 by using exact string equality.

See telekom/kong-plugin-jwt-keycloak#13 for full details.

## Changes

- `Dockerfile` — bump `PLUGIN_VERSION` from `1.8.0-1` to `1.8.1-1` (both build and install stages)
- `.gitmodules` + submodule — update jwt-keycloak submodule to `1.8.1-1`

DHEI-20558