### PR TITLE
chore: enable debug logging in keycloak plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external-plugins/jwt-keycloak"]
 	path = external-plugins/jwt-keycloak
 	url = https://github.com/telekom/kong-plugin-jwt-keycloak.git
-	tag = 1.8.1-1
+	branch = chore/debug-log-token

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /tmp
 
 COPY ./external-plugins/jwt-keycloak/*.rockspec /tmp
 COPY ./external-plugins/jwt-keycloak/src /tmp/src
-ARG PLUGIN_VERSION=1.8.1-1
+ARG PLUGIN_VERSION=1.8.0-1
 RUN luarocks make && luarocks pack kong-plugin-jwt-keycloak ${PLUGIN_VERSION}
 
 
@@ -32,7 +32,7 @@ COPY --from=jwt-keycloak-builder /tmp/*.rock /tmp/
 USER root
 
 # Install jwt-keycloak plugin
-ARG PLUGIN_VERSION=1.8.1-1
+ARG PLUGIN_VERSION=1.8.0-1
 RUN luarocks install /tmp/kong-plugin-jwt-keycloak-${PLUGIN_VERSION}.all.rock
 
 # copy other plugins from repo to image


### PR DESCRIPTION
Temporary test branch: points the jwt-keycloak plugin submodule to `chore/debug-log-token` to enable debug token logging.