### PR TITLE
fix(deps): bump Kong base image 3.9.1 -> 3.9.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           extra_plugins: |
             semantic-release-export-data
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG KONG_VERSION=3.9.1
+ARG KONG_VERSION=3.9.3
 
 FROM kong:${KONG_VERSION} AS jwt-keycloak-builder
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC0-1.0
 ## Overview
 
 This repository contains a custom Kong distribution for the Open Telekom Integration
-Platform (O28M). The API Gateway is based on **Kong OSS 3.9.1** with comprehensive customizations.
+Platform (O28M). The API Gateway is based on **Kong OSS 3.9.3** with comprehensive customizations.
 
 The plugins within this repository are based on the official Kong 3.9.1 plugins and have been enhanced with
 Deutsche Telekom-specific features including memory optimization, enhanced consumer tracking, latency spike prevention,
@@ -137,7 +137,7 @@ both shipped in the image; the Helm chart selects exactly one at runtime
 ## Docker Compose Services
 
 - **kong_init:** Initializes the Kong database with migrations
-- **kong:** Runs the Kong 3.9.1 API Gateway with custom plugins
+- **kong:** Runs the Kong 3.9.3 API Gateway with custom plugins
 - **postgres:** PostgreSQL database for Kong
 - **iris:** Keycloak identity provider with HTTP/HTTPS support
 - **jaeger:** Jaeger tracing collector and UI
@@ -149,14 +149,14 @@ both shipped in the image; the Helm chart selects exactly one at runtime
 The `Dockerfile` is used to build a custom Kong OSS image with the `jwt-keycloak` and `rate-limiting-merged` plugins as
 well as patched versions of `prometheus` and `zipkin`.
 
-The Dockerfile is based on the official Kong 3.9.1 OSS image and includes:
+The Dockerfile is based on the official Kong 3.9.3 OSS image and includes:
 
 - Build and install the external plugin `jwt-keycloak` via `luarocks`
 - Add the `rate-limiting-merged` plugin with Kong 3.9.1 PDK APIs
 - Enhanced `prometheus` plugin with Deutsche Telekom customizations
 - Enhanced `zipkin` plugin with Kong 3.9.1 observability framework
 
-**Kong OSS version:** 3.9.1 (Latest with AI Gateway capabilities)
+**Kong OSS version:** 3.9.3 (Latest with AI Gateway capabilities)
 
 ## Deutsche Telekom Customizations
 


### PR DESCRIPTION
Resolves OpenSSL CVE-2026-45447 (HIGH) plus 7 nginx CVEs fixed in 3.9.2/3.9.3. Same Ubuntu 24.04 base, no breaking changes. Trivy scan clean (0 CRITICAL/HIGH); plugin integration tests pass.