### PR TITLE
chore: migrate image push credentials to Artifactory org secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ name: Build image
 # - with the provided tag if dispatched manually
 
 # Required variables:
-# - REGISTRY_HOST: e.g. mtr.devops.telekom.de
-# - REGISTRY_REPO: e.g. /tardis-internal/gateway/rotator
-# - REGISTRY_AUTH_USER: Name of MTR robot user
+# - REGISTRY_HOST: e.g. registry.example.com
+# - REGISTRY_REPO: e.g. /org/project/kong
 
 # Required secrets:
-# - REGISTRY_AUTH_TOKEN: Name of MTR robot token
+# - ARTIFACTORY_O28M_PUSH_USER: Container registry username
+# - ARTIFACTORY_O28M_PUSH_TOKEN: Container registry password/token
 
 on:
   pull_request:
@@ -80,8 +80,8 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           registry: ${{ vars.REGISTRY_HOST }}
-          username: ${{ vars.REGISTRY_AUTH_USER }}
-          password: ${{ secrets.REGISTRY_AUTH_TOKEN }}
+          username: ${{ secrets.ARTIFACTORY_O28M_PUSH_USER }}
+          password: ${{ secrets.ARTIFACTORY_O28M_PUSH_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 #v3.7.0
       - name: Set up Docker Buildx
@@ -120,8 +120,8 @@ jobs:
           DIGEST: ${{ steps.build-push.outputs.digest }}
           REGISTRY: ${{ vars.REGISTRY_HOST }}
           REGISTRY_REPO: ${{ vars.REGISTRY_REPO }}
-          REGISTRY_USER: ${{ vars.REGISTRY_AUTH_USER }}
-          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_AUTH_TOKEN }}
+          REGISTRY_USER: ${{ secrets.ARTIFACTORY_O28M_PUSH_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.ARTIFACTORY_O28M_PUSH_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
       - name: Verify signature
@@ -140,8 +140,8 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
         env:
-          TRIVY_USERNAME: ${{ vars.REGISTRY_AUTH_USER }}
-          TRIVY_PASSWORD: ${{ secrets.REGISTRY_AUTH_TOKEN }}
+          TRIVY_USERNAME: ${{ secrets.ARTIFACTORY_O28M_PUSH_USER }}
+          TRIVY_PASSWORD: ${{ secrets.ARTIFACTORY_O28M_PUSH_TOKEN }}
         with:
           image-ref: "${{ vars.REGISTRY_HOST }}${{ vars.REGISTRY_REPO }}@${{ needs.build-push-image.outputs.image-digest }}"
           exit-code: "1"


### PR DESCRIPTION
Migrates registry authentication to the new organization-level Artifactory secrets as part of the gateway-wide MTR → Artifactory migration.

## Changes (`.github/workflows/build.yml`)
- Registry auth now uses org secrets `ARTIFACTORY_O28M_PUSH_USER` / `ARTIFACTORY_O28M_PUSH_TOKEN` in all three places: the docker/buildx login step (`username`/`password`), the `cosign login` env block, and the Trivy scan credentials.
- Previously this repo used the per-repo `vars.REGISTRY_AUTH_USER` + `secrets.REGISTRY_AUTH_TOKEN`; both are removed here.
- Header comments made registry-agnostic; `REGISTRY_REPO` example updated to a generic placeholder.

## Not changed
- `REGISTRY_HOST` and `REGISTRY_REPO` remain **per-repo variables** (they differ per repo).

## Follow-up (after merge)
- The old per-repo `REGISTRY_AUTH_USER` variable and `REGISTRY_AUTH_TOKEN` secret can be deleted from the repo settings.